### PR TITLE
chore(release): update versions for SDK packages to 1.0.1 and 1.0.0

### DIFF
--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orga-ai/react-native",
-  "version": "1.0.0-test.2",
+  "version": "1.0.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/packages/sdk-web/package.json
+++ b/packages/sdk-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orga-ai/react",
-  "version": "1.0.0-test.2",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
# Overview

### Made SDKs public

- Manual version bump for @orga-ai/react-native to 1.0.1.
- Manual version bump for @orga-ai/react to 1.0.0.